### PR TITLE
do not strip pkg_dir in extract folder

### DIFF
--- a/opam-doc/opamDoc.ml
+++ b/opam-doc/opamDoc.ml
@@ -70,9 +70,9 @@ let extract output pkg pkg_dir list =
   let prefix = "_build/" in
   let prefix_len = String.length prefix in
   let pkg_dir =
-    if List.length list > 0 && List.for_all (begins_with prefix_len prefix) list
-    then
-      String.sub pkg_dir prefix_len (String.length pkg_dir - prefix_len)
+    if list <> [] && begins_with prefix_len prefix pkg_dir &&
+       List.for_all (begins_with prefix_len prefix) list
+    then String.sub pkg_dir prefix_len (String.length pkg_dir - prefix_len)
     else pkg_dir
   in
   match get_package_version pkg with


### PR DESCRIPTION
It is not obvious when we really need to strip the `_build/` prefix,
but stripping is definitely made under the assumption that the `pkg_dir`
starts with `_build/`. This assumption might not hold. Issue #94
demonstrates it. To fix #94 it is proposed to apply the stripping only
if `pkg_dir` indeed starts with `_build`.

It is possible, that a better solution would be to strip `_build` if the
pkg_dir starts with `_build` without checking the list of
extractables. Or even don't strip if it is not needed.